### PR TITLE
Add three.js dependency to package.json

### DIFF
--- a/racevolt/package.json
+++ b/racevolt/package.json
@@ -11,7 +11,8 @@
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.13",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "three": "^0.169.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Include the three.js library as a dependency for enhanced 3D graphics capabilities.